### PR TITLE
Fix success logic in FileCacheStore

### DIFF
--- a/src/CacheStore/FileCacheStore.php
+++ b/src/CacheStore/FileCacheStore.php
@@ -222,8 +222,9 @@ class FileCacheStore implements CacheerInterface
 
         if ($this->isSuccess()) {
             $this->setMessage("Cache key: {$cacheKey} exists and it's available! from file driver", true);
+        } else {
+            $this->setMessage("Cache key: {$cacheKey} does not exists or it's expired! from file driver", false);
         }
-        $this->setMessage("Cache key: {$cacheKey} does not exists or it's expired! from file driver", false);
     }
 
     /**
@@ -238,6 +239,8 @@ class FileCacheStore implements CacheerInterface
         if ($cacheData) {
             $this->putCache($cacheKey, $cacheData, $namespace, $ttl);
             $this->setMessage("Cache with key {$cacheKey} renewed successfully", true);
+            $this->logger->debug("{$this->getMessage()} from file driver.");
+            return;
         }
         $this->setMessage("Failed to renew Cache with key {$cacheKey}", false);
         $this->logger->debug("{$this->getMessage()} from file driver.");


### PR DESCRIPTION
## Summary
- fix `has` method message logic
- ensure `renewCache` keeps success message when renewal works

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846538095b88332a30abe493b8f5fd3