### PR TITLE
Rename cache directory test

### DIFF
--- a/tests/Feature/OptionBuildTest.php
+++ b/tests/Feature/OptionBuildTest.php
@@ -25,7 +25,7 @@ class OptionBuildTest extends TestCase
     $this->cache->flushCache();
   }
 
-  public function test_it_can_set_cache_diretory()
+  public function test_it_can_set_cache_directory()
   {
     $cacheDir = __DIR__ . "/cache";
 


### PR DESCRIPTION
## Summary
- fix typo in test name `test_it_can_set_cache_directory`

## Testing
- `vendor/bin/phpunit tests/Feature/OptionBuildTest.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68465517b4788332882a25631d7365a5