### PR TITLE
Fix FileCacheStore has message logic

### DIFF
--- a/src/CacheStore/FileCacheStore.php
+++ b/src/CacheStore/FileCacheStore.php
@@ -222,7 +222,9 @@ class FileCacheStore implements CacheerInterface
 
         if ($this->isSuccess()) {
             $this->setMessage("Cache key: {$cacheKey} exists and it's available! from file driver", true);
+            return;
         }
+
         $this->setMessage("Cache key: {$cacheKey} does not exists or it's expired! from file driver", false);
     }
 


### PR DESCRIPTION
## Summary
- correct has() in FileCacheStore so failure message only set when needed

## Testing
- `vendor/bin/phpunit tests/Unit/FileCacheStoreTest.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6846555252f483328dcac34fbbe81814