### PR TITLE
Extract auto flush logic into new FileCacheFlusher

### DIFF
--- a/src/CacheStore/CacheManager/FileCacheFlusher.php
+++ b/src/CacheStore/CacheManager/FileCacheFlusher.php
@@ -6,14 +6,32 @@ use Silviooosilva\CacheerPhp\Helpers\CacheFileHelper;
 
 /**
  * Class FileCacheFlusher
- * Manages flushing and auto-flush scheduling for file cache.
+ * @author Sílvio Silva <https://github.com/silviooosilva>
+ * @package Silviooosilva\CacheerPhp
  */
 class FileCacheFlusher
 {
+    /**
+    * @var FileCacheManager
+    */
     private FileCacheManager $fileManager;
+
+    /**
+    * @var string $cacheDir
+    */
     private string $cacheDir;
+
+    /**
+    * @var string $lastFlushTimeFile
+    */
     private string $lastFlushTimeFile;
 
+    /**
+     * FileCacheFlusher constructor.
+     *
+     * @param FileCacheManager $fileManager
+     * @param string $cacheDir
+     */
     public function __construct(FileCacheManager $fileManager, string $cacheDir)
     {
         $this->fileManager = $fileManager;
@@ -22,18 +40,23 @@ class FileCacheFlusher
     }
 
     /**
-     * Flushes all cache items and updates the last flush timestamp.
-     */
-    public function flushCache(): void
+    * Flushes all cache items and updates the last flush timestamp.
+    *
+    * @return void
+    */
+    public function flushCache()
     {
         $this->fileManager->clearDirectory($this->cacheDir);
         file_put_contents($this->lastFlushTimeFile, time());
     }
 
     /**
-     * Handles the auto-flush functionality based on options.
-     */
-    public function handleAutoFlush(array $options): void
+    * Handles the auto-flush functionality based on options.
+    *
+    * @param array $options
+    * @return void
+    */
+    public function handleAutoFlush(array $options)
     {
         if (isset($options['flushAfter'])) {
             $this->scheduleFlush($options['flushAfter']);
@@ -41,9 +64,12 @@ class FileCacheFlusher
     }
 
     /**
-     * Schedules a flush operation based on the provided interval.
-     */
-    private function scheduleFlush(string $flushAfter): void
+    * Schedules a flush operation based on the provided interval.
+    *
+    * @param string $flushAfter
+    * @return void
+    */
+    private function scheduleFlush(string $flushAfter)
     {
         $flushAfterSeconds = CacheFileHelper::convertExpirationToSeconds($flushAfter);
 

--- a/src/CacheStore/CacheManager/FileCacheFlusher.php
+++ b/src/CacheStore/CacheManager/FileCacheFlusher.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Silviooosilva\CacheerPhp\CacheStore\CacheManager;
+
+use Silviooosilva\CacheerPhp\Helpers\CacheFileHelper;
+
+/**
+ * Class FileCacheFlusher
+ * Manages flushing and auto-flush scheduling for file cache.
+ */
+class FileCacheFlusher
+{
+    private FileCacheManager $fileManager;
+    private string $cacheDir;
+    private string $lastFlushTimeFile;
+
+    public function __construct(FileCacheManager $fileManager, string $cacheDir)
+    {
+        $this->fileManager = $fileManager;
+        $this->cacheDir = $cacheDir;
+        $this->lastFlushTimeFile = "$cacheDir/last_flush_time";
+    }
+
+    /**
+     * Flushes all cache items and updates the last flush timestamp.
+     */
+    public function flushCache(): void
+    {
+        $this->fileManager->clearDirectory($this->cacheDir);
+        file_put_contents($this->lastFlushTimeFile, time());
+    }
+
+    /**
+     * Handles the auto-flush functionality based on options.
+     */
+    public function handleAutoFlush(array $options): void
+    {
+        if (isset($options['flushAfter'])) {
+            $this->scheduleFlush($options['flushAfter']);
+        }
+    }
+
+    /**
+     * Schedules a flush operation based on the provided interval.
+     */
+    private function scheduleFlush(string $flushAfter): void
+    {
+        $flushAfterSeconds = CacheFileHelper::convertExpirationToSeconds($flushAfter);
+
+        if (!$this->fileManager->fileExists($this->lastFlushTimeFile)) {
+            $this->fileManager->writeFile($this->lastFlushTimeFile, time());
+            return;
+        }
+
+        $lastFlushTime = (int) $this->fileManager->readFile($this->lastFlushTimeFile);
+
+        if ((time() - $lastFlushTime) >= $flushAfterSeconds) {
+            $this->flushCache();
+            $this->fileManager->writeFile($this->lastFlushTimeFile, time());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- refactor FileCacheStore by extracting auto flush behavior
- create `FileCacheFlusher` class to manage flush scheduling

## Testing
- `php -l src/CacheStore/CacheManager/FileCacheFlusher.php`
- `php -l src/CacheStore/FileCacheStore.php`
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687784c93e2883329d25436ef0bc324e