### PR TITLE
Return operation status from cache methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,19 @@ $value = ['id' => 123, 'name' => 'John Doe'];
 // Store data
 $cache->putCache($key, $value);
 
-// Retrieve data
-$cached = $cache->getCache($key);
-
-if ($cache->isSuccess()) {
+// Retrieve data using boolean return
+if ($cache->has($key)) {
+    $cached = $cache->getCache($key);
     var_dump($cached);
 } else {
     echo $cache->getMessage();
+}
+
+// Alternatively, check the state via isSuccess()
+$cache->has($key);
+if ($cache->isSuccess()) {
+    $cached = $cache->getCache($key);
+    var_dump($cached);
 }
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/silviooosilva",
   "type": "library",
   "license": "MIT",
-  "version": "v4.2.0",
+  "version": "v4.3.0",
   "autoload": {
     "files": [
       "src/Boot/Configs.php"

--- a/docs/API-Reference/FuncoesCache/README.md
+++ b/docs/API-Reference/FuncoesCache/README.md
@@ -248,9 +248,9 @@ $Cacheer->useEncryption('secret-key');
 ```
 ---
 
-Each of the functions below allows you to interact with the cache in different ways. Functions that “return void” actually set the status of the operation internally, which can be checked via:
+Each of the functions below now returns a boolean indicating the success of the operation. If you prefer, you can still check the status separately:
 
 ```php
-$Cacheer->isSuccess(); // Returns true ou false
+$Cacheer->isSuccess(); // Returns true or false
 $Cacheer->getMessage(); // Returns a message
 ```

--- a/docs/example01.md
+++ b/docs/example01.md
@@ -28,11 +28,18 @@ $Cacheer->putCache($cacheKey, $userProfile);
 // Retrieving data from the cache
 $cachedProfile = $Cacheer->getCache($cacheKey);
 
-if ($Cacheer->isSuccess()) {
+if ($Cacheer->has($cacheKey)) {
     echo "Cache Found: ";
     print_r($cachedProfile);
 } else {
     echo $Cacheer->getMessage();
+}
+
+// Alternatively, using the previous style
+$Cacheer->has($cacheKey);
+if ($Cacheer->isSuccess()) {
+    echo "Cache Found: ";
+    print_r($cachedProfile);
 }
 
 ```

--- a/docs/example02.md
+++ b/docs/example02.md
@@ -29,11 +29,18 @@ $Cacheer->putCache($cacheKey, $dailyStats);
 // Recuperando dados do cache por 2 horas
 $cachedStats = $Cacheer->getCache($cacheKey, 'namespace', '2 hours'); //Segunda opção (definição no método)
 
-if ($Cacheer->isSuccess()) {
+if ($Cacheer->has($cacheKey, 'namespace')) {
     echo "Cache Found: ";
     print_r($cachedStats);
 } else {
     echo $Cacheer->getMessage();
+}
+
+// Ou utilizando isSuccess()
+$Cacheer->has($cacheKey, 'namespace');
+if ($Cacheer->isSuccess()) {
+    echo "Cache Found: ";
+    print_r($cachedStats);
 }
 
 ```

--- a/docs/example03.md
+++ b/docs/example03.md
@@ -18,20 +18,17 @@ $Cacheer = new Cacheer($options);
 $cacheKey = 'user_profile_123';
 
 // Clearing a specific item from the cache
-
-$Cacheer->clearCache($cacheKey);
-
-if ($Cacheer->isSuccess()) {
-    echo $Cacheer->getMessage();
-} else {
+if ($Cacheer->clearCache($cacheKey)) {
     echo $Cacheer->getMessage();
 }
 
-$Cacheer->flushCache();
-
-if ($Cacheer->isSuccess()) {
+if ($Cacheer->flushCache()) {
     echo $Cacheer->getMessage();
-} else {
+}
+
+// Utilizando isSuccess()
+$Cacheer->clearCache($cacheKey);
+if ($Cacheer->isSuccess()) {
     echo $Cacheer->getMessage();
 }
 

--- a/docs/example04.md
+++ b/docs/example04.md
@@ -27,10 +27,17 @@ $Cacheer->putCache($cacheKey, $sessionData, $namespace);
 // Retrieving data from the cache
 $cachedSessionData = $Cacheer->getCache($cacheKey, $namespace);
 
-if ($Cacheer->isSuccess()) {
+if ($Cacheer->has($cacheKey, $namespace)) {
     echo "Cache Found: ";
     print_r($cachedSessionData);
 } else {
     echo $Cacheer->getMessage();
+}
+
+// Alternativamente
+$Cacheer->has($cacheKey, $namespace);
+if ($Cacheer->isSuccess()) {
+    echo "Cache Found: ";
+    print_r($cachedSessionData);
 }
 ```

--- a/docs/example05.md
+++ b/docs/example05.md
@@ -21,13 +21,19 @@ $cacheKey = 'api_response_' . md5($apiUrl);
 // Checking if the API response is already in the cache
 $cachedResponse = $Cacheer->getCache($cacheKey);
 
-if ($Cacheer->isSuccess()) {
+if ($Cacheer->has($cacheKey)) {
     // Use the cache response
     $response = $cachedResponse;
 } else {
     // Call the API and store the response in the cache
     $response = file_get_contents($apiUrl);
     $Cacheer->putCache($cacheKey, $response);
+}
+
+// Ou utilizando isSuccess()
+$Cacheer->has($cacheKey);
+if ($Cacheer->isSuccess()) {
+    $response = $cachedResponse;
 }
 
 // Using the API response (from cache or call)

--- a/docs/example06.md
+++ b/docs/example06.md
@@ -32,15 +32,22 @@ $Cacheer->putCache($cacheKey, $userProfile);
 // Retrieving data from the cache in JSON format
 
 $cachedProfile = $Cacheer->getCache(
-$cacheKey, 
-$namespace, 
+$cacheKey,
+$namespace,
 $ttl)->toJson();
 
-if ($Cacheer->isSuccess()) {
+if ($Cacheer->has($cacheKey)) {
 echo  "Cache Found: ";
 print_r($cachedProfile);
 } else {
 echo  $Cacheer->getMessage();
+}
+
+// Ou utilizando isSuccess()
+$Cacheer->has($cacheKey);
+if ($Cacheer->isSuccess()) {
+echo  "Cache Found: ";
+print_r($cachedProfile);
 }
 
 ```

--- a/docs/example07.md
+++ b/docs/example07.md
@@ -33,15 +33,22 @@ $Cacheer->putCache($cacheKey, $userProfile);
 // Retrieving data from the cache in JSON format
 
 $cachedProfile = $Cacheer->getCache(
-$cacheKey, 
-$namespace, 
+$cacheKey,
+$namespace,
 $ttl)->toArray();
 
-if ($Cacheer->isSuccess()) {
+if ($Cacheer->has($cacheKey)) {
 echo  "Cache Found: ";
 print_r($cachedProfile);
 } else {
 echo  $Cacheer->getMessage();
+}
+
+// Ou utilizando isSuccess()
+$Cacheer->has($cacheKey);
+if ($Cacheer->isSuccess()) {
+echo  "Cache Found: ";
+print_r($cachedProfile);
 }
 
 ```

--- a/docs/example08.md
+++ b/docs/example08.md
@@ -33,15 +33,22 @@ $Cacheer->putCache($cacheKey, $userProfile);
 // Retrieving data from the cache in JSON format
 
 $cachedProfile = $Cacheer->getCache(
-$cacheKey, 
-$namespace, 
+$cacheKey,
+$namespace,
 $ttl)->toString();
 
-if ($Cacheer->isSuccess()) {
+if ($Cacheer->has($cacheKey)) {
 echo  "Cache Found: ";
 print_r($cachedProfile);
 } else {
 echo  $Cacheer->getMessage();
+}
+
+// Ou utilizando isSuccess()
+$Cacheer->has($cacheKey);
+if ($Cacheer->isSuccess()) {
+echo  "Cache Found: ";
+print_r($cachedProfile);
 }
 
 ```

--- a/docs/example09.md
+++ b/docs/example09.md
@@ -36,11 +36,18 @@ $Cacheer->putCache($cacheKey, $userProfile);
 
 $cachedProfile = $Cacheer->getCache($cacheKey);
 
-if ($Cacheer->isSuccess()) {
+if ($Cacheer->has($cacheKey)) {
 echo  "Cache Found: ";
 print_r($cachedProfile);
 } else {
 echo  $Cacheer->getMessage();
+}
+
+// Ou utilizando isSuccess()
+$Cacheer->has($cacheKey);
+if ($Cacheer->isSuccess()) {
+echo  "Cache Found: ";
+print_r($cachedProfile);
 }
 
 

--- a/src/CacheStore/ArrayCacheStore.php
+++ b/src/CacheStore/ArrayCacheStore.php
@@ -248,7 +248,15 @@ class ArrayCacheStore implements CacheerInterface
   public function has(string $cacheKey, string $namespace = ''): bool
   {
     $arrayStoreKey = $this->buildArrayKey($cacheKey, $namespace);
-    return isset($this->arrayStore[$arrayStoreKey]) && time() < $this->arrayStore[$arrayStoreKey]['expirationTime'];
+    $exists = isset($this->arrayStore[$arrayStoreKey]) && time() < $this->arrayStore[$arrayStoreKey]['expirationTime'];
+
+    $this->setMessage(
+      $exists ? "Cache key: {$cacheKey} exists and it's available!" : "Cache key: {$cacheKey} does not exist or it's expired!",
+      $exists
+    );
+    $this->logger->debug("{$this->getMessage()} from array driver.");
+
+    return $exists;
   }
 
   /**

--- a/src/CacheStore/DatabaseCacheStore.php
+++ b/src/CacheStore/DatabaseCacheStore.php
@@ -185,15 +185,22 @@ class DatabaseCacheStore implements CacheerInterface
      * 
      * @param string $cacheKey
      * @param string $namespace
-     * @return void
+     * @return bool
      */
-    public function has(string $cacheKey, string $namespace = ''): void
+    public function has(string $cacheKey, string $namespace = ''): bool
     {
         $cacheData = $this->getCache($cacheKey, $namespace);
+
         if ($cacheData) {
-            $this->logger->debug("Cache key: {$cacheKey} exists and it's available from database driver.");
+            $this->setMessage("Cache key: {$cacheKey} exists and it's available from database driver.", true);
+            $this->logger->debug("{$this->getMessage()}");
+            return true;
         }
-        $this->logger->warning("{$this->getMessage()} from database driver.");
+
+        $this->setMessage("Cache key: {$cacheKey} does not exist or it's expired from database driver.", false);
+        $this->logger->debug("{$this->getMessage()}");
+
+        return false;
     }
 
     /**

--- a/src/CacheStore/FileCacheStore.php
+++ b/src/CacheStore/FileCacheStore.php
@@ -131,7 +131,7 @@ class FileCacheStore implements CacheerInterface
      *
      * @param string $cacheKey
      * @param string $namespace
-     * @return void
+     * @return bool
      * @throws CacheFileException
      */
     public function clearCache(string $cacheKey, string $namespace = ''): void
@@ -340,18 +340,20 @@ class FileCacheStore implements CacheerInterface
      *
      * @param string $cacheKey
      * @param string $namespace
-     * @return void
+     * @return bool
      * @throws CacheFileException
      */
-    public function has(string $cacheKey, string $namespace = ''): void
+    public function has(string $cacheKey, string $namespace = ''): bool
     {
         $this->getCache($cacheKey, $namespace);
 
         if ($this->isSuccess()) {
             $this->setMessage("Cache key: {$cacheKey} exists and it's available! from file driver", true);
-        } else {
-            $this->setMessage("Cache key: {$cacheKey} does not exists or it's expired! from file driver", false);
+            return true;
         }
+
+        $this->setMessage("Cache key: {$cacheKey} does not exists or it's expired! from file driver", false);
+        return false;
     }
 
     /**

--- a/src/CacheStore/RedisCacheStore.php
+++ b/src/CacheStore/RedisCacheStore.php
@@ -56,7 +56,7 @@ class RedisCacheStore implements CacheerInterface
      * @param string $cacheKey
      * @param mixed  $cacheData
      * @param string $namespace
-     * @return void
+     * @return bool
      */
     public function appendCache(string $cacheKey, mixed $cacheData, string $namespace = ''): void
     {
@@ -233,19 +233,21 @@ class RedisCacheStore implements CacheerInterface
      * 
      * @param string $cacheKey
      * @param string $namespace
-     * @return void
+     * @return bool
      */
-    public function has(string $cacheKey, string $namespace = ''): void
+    public function has(string $cacheKey, string $namespace = ''): bool
     {
         $cacheFullKey = $this->buildKey($cacheKey, $namespace);
 
         if ($this->redis->exists($cacheFullKey) > 0) {
             $this->setMessage("Cache Key: {$cacheKey} exists!", true);
-        } else {
-            $this->setMessage("Cache Key: {$cacheKey} does not exists!", false);
+            $this->logger->debug("{$this->getMessage()} from redis driver.");
+            return true;
         }
 
+        $this->setMessage("Cache Key: {$cacheKey} does not exists!", false);
         $this->logger->debug("{$this->getMessage()} from redis driver.");
+        return false;
     }
 
     /**

--- a/src/Cacheer.php
+++ b/src/Cacheer.php
@@ -103,11 +103,11 @@ final class Cacheer implements CacheerInterface
     * @param string $cacheKey
     * @param mixed  $cacheData
     * @param string $namespace
-    * @return void
+    * @return bool
     */
-    public function appendCache(string $cacheKey, mixed $cacheData, string $namespace = ''): void
+    public function appendCache(string $cacheKey, mixed $cacheData, string $namespace = ''): bool
     {
-        $this->mutator->appendCache($cacheKey, $cacheData, $namespace);
+        return $this->mutator->appendCache($cacheKey, $cacheData, $namespace);
     }
 
     /**
@@ -115,11 +115,11 @@ final class Cacheer implements CacheerInterface
     * 
     * @param string $cacheKey
     * @param string $namespace
-    * @return void
+    * @return bool
     */
-    public function clearCache(string $cacheKey, string $namespace = ''): void
+    public function clearCache(string $cacheKey, string $namespace = ''): bool
     {
-        $this->mutator->clearCache($cacheKey, $namespace);
+        return $this->mutator->clearCache($cacheKey, $namespace);
     }
 
     /**
@@ -140,21 +140,21 @@ final class Cacheer implements CacheerInterface
     *
     * @param string $cacheKey
     * @param mixed $cacheData
-    * @return void
+    * @return bool
     */
-    public function forever(string $cacheKey, mixed $cacheData): void
+    public function forever(string $cacheKey, mixed $cacheData): bool
     {
-        $this->mutator->forever($cacheKey, $cacheData);
+        return $this->mutator->forever($cacheKey, $cacheData);
     }
 
     /**
     * Flushes all cache items.
-    * 
-    * @return void
+    *
+    * @return bool
     */
-    public function flushCache(): void
+    public function flushCache(): bool
     {
-        $this->mutator->flushCache();
+        return $this->mutator->flushCache();
     }
 
     /**
@@ -208,14 +208,14 @@ final class Cacheer implements CacheerInterface
 
     /**
     * Checks if a cache item exists.
-    * 
+    *
     * @param string $cacheKey
     * @param string $namespace
-    * @return void
+    * @return bool
     */
-    public function has(string $cacheKey, string $namespace = ''): void
+    public function has(string $cacheKey, string $namespace = ''): bool
     {
-        $this->retriever->has($cacheKey, $namespace);
+        return $this->retriever->has($cacheKey, $namespace);
     }
 
     /**
@@ -248,11 +248,11 @@ final class Cacheer implements CacheerInterface
     * @param mixed  $cacheData
     * @param string $namespace
     * @param string|int $ttl
-    * @return void
+    * @return bool
     */
-    public function putCache(string $cacheKey, mixed $cacheData, string $namespace = '', string|int $ttl = 3600): void
+    public function putCache(string $cacheKey, mixed $cacheData, string $namespace = '', string|int $ttl = 3600): bool
     {
-        $this->mutator->putCache($cacheKey, $cacheData, $namespace, $ttl);
+        return $this->mutator->putCache($cacheKey, $cacheData, $namespace, $ttl);
     }
 
     /**
@@ -261,11 +261,11 @@ final class Cacheer implements CacheerInterface
     * @param array   $items
     * @param string  $namespace
     * @param integer $batchSize
-    * @return void
+    * @return bool
     */
-    public function putMany(array $items, string $namespace = '', int $batchSize = 100): void
+    public function putMany(array $items, string $namespace = '', int $batchSize = 100): bool
     {
-        $this->mutator->putMany($items, $namespace, $batchSize);
+        return $this->mutator->putMany($items, $namespace, $batchSize);
     }
 
     /**
@@ -274,11 +274,11 @@ final class Cacheer implements CacheerInterface
     * @param string $cacheKey
     * @param string|int $ttl
     * @param string $namespace
-    * @return void
+    * @return bool
     */
-    public function renewCache(string $cacheKey, string|int $ttl = 3600, string $namespace = ''): void
+    public function renewCache(string $cacheKey, string|int $ttl = 3600, string $namespace = ''): bool
     {
-        $this->mutator->renewCache($cacheKey, $ttl, $namespace);
+        return $this->mutator->renewCache($cacheKey, $ttl, $namespace);
     }
 
     /**

--- a/src/Interface/CacheerInterface.php
+++ b/src/Interface/CacheerInterface.php
@@ -71,7 +71,7 @@ interface CacheerInterface
      * @param string $namespace Namespace for organization
      * @return bool True if the item exists, false otherwise
      */
-    public function has(string $cacheKey, string $namespace = '');
+    public function has(string $cacheKey, string $namespace = ''): bool;
 
     /**
      * Stores an item in the cache with a specific TTL.

--- a/src/Service/CacheMutator.php
+++ b/src/Service/CacheMutator.php
@@ -54,12 +54,14 @@ class CacheMutator
     * @param string $cacheKey
     * @param mixed $cacheData
     * @param string $namespace
-    * @return void
+    * @return bool
     */
-    public function appendCache(string $cacheKey, mixed $cacheData, string $namespace = ''): void
+    public function appendCache(string $cacheKey, mixed $cacheData, string $namespace = ''): bool
     {
         $this->cacheer->cacheStore->appendCache($cacheKey, $cacheData, $namespace);
         $this->cacheer->syncState();
+
+        return $this->cacheer->isSuccess();
     }
 
     /**
@@ -67,12 +69,14 @@ class CacheMutator
     *
     * @param string $cacheKey
     * @param string $namespace
-    * @return void
+    * @return bool
     */
-    public function clearCache(string $cacheKey, string $namespace = ''): void
+    public function clearCache(string $cacheKey, string $namespace = ''): bool
     {
         $this->cacheer->cacheStore->clearCache($cacheKey, $namespace);
         $this->cacheer->syncState();
+
+        return $this->cacheer->isSuccess();
     }
 
     /**
@@ -93,23 +97,27 @@ class CacheMutator
      *
      * @param string $cacheKey
      * @param mixed $cacheData
-     * @return void
+     * @return bool
      */
-    public function forever(string $cacheKey, mixed $cacheData): void
+    public function forever(string $cacheKey, mixed $cacheData): bool
     {
         $this->putCache($cacheKey, $cacheData, ttl: 31536000 * 1000);
         $this->cacheer->setInternalState($this->cacheer->getMessage(), $this->cacheer->isSuccess());
+
+        return $this->cacheer->isSuccess();
     }
 
     /**
     * Flushes the entire cache.
     *
-    * @return void
+    * @return bool
     */
-    public function flushCache(): void
+    public function flushCache(): bool
     {
         $this->cacheer->cacheStore->flushCache();
         $this->cacheer->syncState();
+
+        return $this->cacheer->isSuccess();
     }
 
     /**
@@ -140,13 +148,15 @@ class CacheMutator
      * @param mixed $cacheData
      * @param string $namespace
      * @param int|string $ttl
-     * @return void
+     * @return bool
      */
-    public function putCache(string $cacheKey, mixed $cacheData, string $namespace = '', int|string $ttl = 3600): void
+    public function putCache(string $cacheKey, mixed $cacheData, string $namespace = '', int|string $ttl = 3600): bool
     {
         $data = CacheerHelper::prepareForStorage($cacheData, $this->cacheer->isCompressionEnabled(), $this->cacheer->getEncryptionKey());
         $this->cacheer->cacheStore->putCache($cacheKey, $data, $namespace, $ttl);
         $this->cacheer->syncState();
+
+        return $this->cacheer->isSuccess();
     }
 
     /**
@@ -155,11 +165,14 @@ class CacheMutator
     * @param array $items
     * @param string $namespace
     * @param int $batchSize
-    * @return void
+    * @return bool
     */
-    public function putMany(array $items, string $namespace = '', int $batchSize = 100): void
+    public function putMany(array $items, string $namespace = '', int $batchSize = 100): bool
     {
         $this->cacheer->cacheStore->putMany($items, $namespace, $batchSize);
+        $this->cacheer->syncState();
+
+        return $this->cacheer->isSuccess();
     }
 
     /**
@@ -168,11 +181,13 @@ class CacheMutator
     * @param string $cacheKey
     * @param int|string $ttl
     * @param string $namespace
-    * @return void
+    * @return bool
     */
-    public function renewCache(string $cacheKey, int|string $ttl = 3600, string $namespace = ''): void
+    public function renewCache(string $cacheKey, int|string $ttl = 3600, string $namespace = ''): bool
     {
         $this->cacheer->cacheStore->renewCache($cacheKey, $ttl, $namespace);
         $this->cacheer->syncState();
+
+        return $this->cacheer->isSuccess();
     }
 }

--- a/src/Service/CacheRetriever.php
+++ b/src/Service/CacheRetriever.php
@@ -140,13 +140,15 @@ class CacheRetriever
      *
      * @param string $cacheKey
      * @param string $namespace
-     * @return void
+     * @return bool
      * @throws CacheFileException
      */
-    public function has(string $cacheKey, string $namespace = ''): void
+    public function has(string $cacheKey, string $namespace = ''): bool
     {
         $this->cacheer->cacheStore->has($cacheKey, $namespace);
         $this->cacheer->syncState();
+
+        return $this->cacheer->isSuccess();
     }
 
     /**

--- a/src/Service/CacheRetriever.php
+++ b/src/Service/CacheRetriever.php
@@ -145,10 +145,10 @@ class CacheRetriever
      */
     public function has(string $cacheKey, string $namespace = ''): bool
     {
-        $this->cacheer->cacheStore->has($cacheKey, $namespace);
+        $result = $this->cacheer->cacheStore->has($cacheKey, $namespace);
         $this->cacheer->syncState();
 
-        return $this->cacheer->isSuccess();
+        return $result;
     }
 
     /**

--- a/tests/Unit/BooleanReturnTest.php
+++ b/tests/Unit/BooleanReturnTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Silviooosilva\CacheerPhp\Cacheer;
+
+class BooleanReturnTest extends TestCase
+{
+    private Cacheer $cache;
+
+    protected function setUp(): void
+    {
+        $this->cache = new Cacheer();
+        $this->cache->setDriver()->useArrayDriver();
+    }
+
+    public function testHasReturnsBoolean()
+    {
+        $this->cache->putCache('bool_key', 'value');
+        $this->assertTrue($this->cache->has('bool_key'));
+        $this->assertTrue($this->cache->isSuccess());
+
+        $this->assertFalse($this->cache->has('unknown_key'));
+        $this->assertFalse($this->cache->isSuccess());
+    }
+
+    public function testMutatingMethodsReturnBoolean()
+    {
+        $this->assertTrue($this->cache->putCache('k', 'v'));
+        $this->assertTrue($this->cache->flushCache());
+        $this->assertTrue($this->cache->putCache('k', 'v'));
+        $this->assertTrue($this->cache->clearCache('k'));
+    }
+}


### PR DESCRIPTION
## Summary
- Return boolean success indicators from cache operations and still expose `isSuccess`
- Document both direct boolean checks and `isSuccess()` usage
- Add tests confirming boolean returns from API methods

## Testing
- `composer install` *(fails: curl error 56 CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aa693167708332ae542cb21d2119a3