### PR TITLE
Enable static access to cache operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,18 +56,22 @@ require_once __DIR__ . '/vendor/autoload.php';
 
 use Silviooosilva\CacheerPhp\Cacheer;
 
-$cache = new Cacheer([
-    'cacheDir' => __DIR__ . '/cache',
-]);
-
 $key   = 'user_profile_1234';
 $value = ['id' => 123, 'name' => 'John Doe'];
 
-// Store data
-$cache->putCache($key, $value);
+// Static usage with boolean return
+Cacheer::putCache($key, $value);
+if (Cacheer::has($key)) {
+    $cached = Cacheer::getCache($key);
+    var_dump($cached);
+}
 
-// Retrieve data using boolean return
-if ($cache->has($key)) {
+// Dynamic usage and isSuccess()
+$cache = new Cacheer([
+    'cacheDir' => __DIR__ . '/cache',
+]);
+$cache->has($key);
+if ($cache->isSuccess()) {
     $cached = $cache->getCache($key);
     var_dump($cached);
 } else {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/silviooosilva",
   "type": "library",
   "license": "MIT",
-  "version": "v4.3.0",
+    "version": "v4.4.0",
   "autoload": {
     "files": [
       "src/Boot/Configs.php"

--- a/docs/API-Reference/FuncoesCache/README.md
+++ b/docs/API-Reference/FuncoesCache/README.md
@@ -4,6 +4,8 @@ CacheerPHP offers a robust set of functions for managing caching in your PHP app
 
 ---
 
+> **Note:** Each method can be called statically using `Cacheer::method()` or dynamically via an instance `$cache->method()`.
+
 ## Basic Cache Operations
 
 ### `getCache()` - Retrieves data from the cache

--- a/docs/API-Reference/optionBuilder.md
+++ b/docs/API-Reference/optionBuilder.md
@@ -53,6 +53,8 @@ $Cacheer = new Cacheer($Options);
 $Cacheer->setDriver()->useFileDriver(); //File Driver
 ```
 
+> **Note:** Cacheer methods may also be called statically, e.g. `Cacheer::setDriver()->useFileDriver();`
+
 #### Coming soon
 
 ```php

--- a/docs/API-Reference/setConfig.md
+++ b/docs/API-Reference/setConfig.md
@@ -16,6 +16,8 @@ $Cacheer = new Cacheer();
 $Cacheer->setConfig();
 ```
 
+> **Note:** Configuration methods can also be called statically, e.g. `Cacheer::setConfig()->setDatabaseConnection('mysql');`
+
 Configures the database for storing the cache.
 ```php
 <?php

--- a/docs/API-Reference/setDriver.md
+++ b/docs/API-Reference/setDriver.md
@@ -11,6 +11,8 @@ $Cacheer = new Cacheer();
 $Cacheer->setDriver();
 ```
 
+> **Note:** The driver methods can also be called statically, e.g. `Cacheer::setDriver()->useFileDriver();`
+
 Defines the cache driver as file-based:
 ```php
 <?php

--- a/docs/example01.md
+++ b/docs/example01.md
@@ -22,6 +22,9 @@ $userProfile = [
     'email' => 'john.doe@example.com',
 ];
 
+// Static call example
+Cacheer::putCache($cacheKey, $userProfile);
+
 // Storing data in the cache
 $Cacheer->putCache($cacheKey, $userProfile);
 

--- a/docs/example02.md
+++ b/docs/example02.md
@@ -23,6 +23,9 @@ $dailyStats = [
     'revenue' => 500.75,
 ];
 
+// Static call example
+Cacheer::putCache($cacheKey, $dailyStats, 'namespace', '2 hours');
+
 // Armazenando dados no cache
 $Cacheer->putCache($cacheKey, $dailyStats);
 

--- a/docs/example03.md
+++ b/docs/example03.md
@@ -14,6 +14,9 @@ $options = [
 
 $Cacheer = new Cacheer($options);
 
+// Static call example
+Cacheer::flushCache();
+
 // Key of the cache to be cleared
 $cacheKey = 'user_profile_123';
 

--- a/docs/example04.md
+++ b/docs/example04.md
@@ -21,6 +21,9 @@ $sessionData = [
     'login_time' => time(),
 ];
 
+// Static call example
+Cacheer::putCache($cacheKey, $sessionData, $namespace);
+
 // Caching data with namespace
 $Cacheer->putCache($cacheKey, $sessionData, $namespace);
 

--- a/docs/example05.md
+++ b/docs/example05.md
@@ -18,6 +18,9 @@ $Cacheer = new Cacheer($options);
 $apiUrl = 'https://jsonplaceholder.typicode.com/posts';
 $cacheKey = 'api_response_' . md5($apiUrl);
 
+// Static call example
+$cachedResponse = Cacheer::getCache($cacheKey);
+
 // Checking if the API response is already in the cache
 $cachedResponse = $Cacheer->getCache($cacheKey);
 

--- a/docs/example06.md
+++ b/docs/example06.md
@@ -25,6 +25,9 @@ $userProfile = [
 'email' => 'john.doe@example.com',
 ];
 
+// Static call example
+Cacheer::putCache($cacheKey, $userProfile);
+
 // Storing data in the cache
 
 $Cacheer->putCache($cacheKey, $userProfile);

--- a/docs/example07.md
+++ b/docs/example07.md
@@ -26,6 +26,9 @@ $userProfile = [
 'email' => 'john.doe@example.com',
 ];
 
+// Static call example
+Cacheer::putCache($cacheKey, $userProfile);
+
 // Storing data in the cache
 
 $Cacheer->putCache($cacheKey, $userProfile);

--- a/docs/example08.md
+++ b/docs/example08.md
@@ -26,6 +26,9 @@ $userProfile = [
 'email' => 'john.doe@example.com',
 ];
 
+// Static call example
+Cacheer::putCache($cacheKey, $userProfile);
+
 // Storing data in the cache
 
 $Cacheer->putCache($cacheKey, $userProfile);

--- a/docs/example09.md
+++ b/docs/example09.md
@@ -28,6 +28,9 @@ $userProfile = [
 'email' => 'john.doe@example.com',
 ];
 
+// Static call example
+Cacheer::putCache($cacheKey, $userProfile);
+
 // Storing data in the cache
 
 $Cacheer->putCache($cacheKey, $userProfile);

--- a/docs/guide2.0.0.md
+++ b/docs/guide2.0.0.md
@@ -70,6 +70,8 @@ $Cacheer->setDriver()->useDatabaseDriver();
 
 ```
 
+> These configuration steps can also be performed statically using `Cacheer::setConfig()->setDatabaseConnection('mysql');`
+
 #### 3) Configure Timezone
 
 - To avoid issues with cache expiration, set the timezone:

--- a/src/Cacheer.php
+++ b/src/Cacheer.php
@@ -14,6 +14,7 @@ use Silviooosilva\CacheerPhp\Utils\CacheDriver;
 use RuntimeException;
 use Silviooosilva\CacheerPhp\Service\CacheRetriever;
 use Silviooosilva\CacheerPhp\Service\CacheMutator;
+use BadMethodCallException;
 
 /**
 * Class CacheerPHP
@@ -67,6 +68,11 @@ final class Cacheer implements CacheerInterface
     */
     private CacheMutator $mutator;
 
+    /**
+    * @var Cacheer|null
+    */
+    private static ?Cacheer $staticInstance = null;
+
 /**
     * Cacheer constructor.
     *
@@ -81,6 +87,11 @@ final class Cacheer implements CacheerInterface
         $this->retriever = new CacheRetriever($this);
         $this->mutator = new CacheMutator($this);
         $this->setDriver()->useDefaultDriver();
+    }
+
+    private static function instance(): Cacheer
+    {
+        return self::$staticInstance ??= new self();
     }
 
     /**
@@ -434,5 +445,21 @@ final class Cacheer implements CacheerInterface
     {
         $this->encryptionKey = $key;
         return $this;
+    }
+
+    /**
+    * Handle dynamic static calls by creating an instance internally.
+    *
+    * @param string $method
+    * @param array $parameters
+    * @return mixed
+    */
+    public static function __callStatic(string $method, array $parameters): mixed
+    {
+        $instance = self::instance();
+        if (!method_exists($instance, $method)) {
+            throw new BadMethodCallException("Method {$method} does not exist");
+        }
+        return $instance->{$method}(...$parameters);
     }
 }

--- a/tests/Unit/StaticAccessTest.php
+++ b/tests/Unit/StaticAccessTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Silviooosilva\CacheerPhp\Cacheer;
+
+final class StaticAccessTest extends TestCase
+{
+    public function testFlushCacheStatic(): void
+    {
+        $result = Cacheer::flushCache();
+        $this->assertIsBool($result);
+    }
+
+    public function testFlushCacheDynamic(): void
+    {
+        $cache = new Cacheer();
+        $this->assertIsBool($cache->flushCache());
+    }
+}


### PR DESCRIPTION
## Summary
- Delegate static method calls to a shared `Cacheer` instance for both static and dynamic usage
- Document static invocation across README, examples, and API reference
- Cover static `flushCache` with a new unit test

## Testing
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aa693167708332ae542cb21d2119a3