### PR TITLE
Enable static access to cache operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,20 +56,23 @@ require_once __DIR__ . '/vendor/autoload.php';
 
 use Silviooosilva\CacheerPhp\Cacheer;
 
-$cache = new Cacheer([
-    'cacheDir' => __DIR__ . '/cache',
-]);
-
 $key   = 'user_profile_1234';
 $value = ['id' => 123, 'name' => 'John Doe'];
 
-// Store data
-$cache->putCache($key, $value);
+// Static usage with boolean return
+Cacheer::putCache($key, $value);
+if (Cacheer::has($key)) {
+    $cached = Cacheer::getCache($key);
+    var_dump($cached);
+}
 
-// Retrieve data
-$cached = $cache->getCache($key);
-
+// Dynamic usage and isSuccess()
+$cache = new Cacheer([
+    'cacheDir' => __DIR__ . '/cache',
+]);
+$cache->has($key);
 if ($cache->isSuccess()) {
+    $cached = $cache->getCache($key);
     var_dump($cached);
 } else {
     echo $cache->getMessage();

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/silviooosilva",
   "type": "library",
   "license": "MIT",
-  "version": "v4.2.0",
+    "version": "v4.4.1",
   "autoload": {
     "files": [
       "src/Boot/Configs.php"

--- a/docs/API-Reference/FuncoesCache/README.md
+++ b/docs/API-Reference/FuncoesCache/README.md
@@ -4,6 +4,8 @@ CacheerPHP offers a robust set of functions for managing caching in your PHP app
 
 ---
 
+> **Note:** Each method can be called statically using `Cacheer::method()` or dynamically via an instance `$cache->method()`.
+
 ## Basic Cache Operations
 
 ### `getCache()` - Retrieves data from the cache
@@ -248,9 +250,9 @@ $Cacheer->useEncryption('secret-key');
 ```
 ---
 
-Each of the functions below allows you to interact with the cache in different ways. Functions that “return void” actually set the status of the operation internally, which can be checked via:
+Each of the functions below now returns a boolean indicating the success of the operation. If you prefer, you can still check the status separately:
 
 ```php
-$Cacheer->isSuccess(); // Returns true ou false
+$Cacheer->isSuccess(); // Returns true or false
 $Cacheer->getMessage(); // Returns a message
 ```

--- a/docs/API-Reference/optionBuilder.md
+++ b/docs/API-Reference/optionBuilder.md
@@ -53,6 +53,8 @@ $Cacheer = new Cacheer($Options);
 $Cacheer->setDriver()->useFileDriver(); //File Driver
 ```
 
+> **Note:** Cacheer methods may also be called statically, e.g. `Cacheer::setDriver()->useFileDriver();`
+
 #### Coming soon
 
 ```php

--- a/docs/API-Reference/setConfig.md
+++ b/docs/API-Reference/setConfig.md
@@ -16,6 +16,8 @@ $Cacheer = new Cacheer();
 $Cacheer->setConfig();
 ```
 
+> **Note:** Configuration methods can also be called statically, e.g. `Cacheer::setConfig()->setDatabaseConnection('mysql');`
+
 Configures the database for storing the cache.
 ```php
 <?php

--- a/docs/API-Reference/setDriver.md
+++ b/docs/API-Reference/setDriver.md
@@ -11,6 +11,8 @@ $Cacheer = new Cacheer();
 $Cacheer->setDriver();
 ```
 
+> **Note:** The driver methods can also be called statically, e.g. `Cacheer::setDriver()->useFileDriver();`
+
 Defines the cache driver as file-based:
 ```php
 <?php

--- a/docs/example01.md
+++ b/docs/example01.md
@@ -22,17 +22,27 @@ $userProfile = [
     'email' => 'john.doe@example.com',
 ];
 
+// Static call example
+Cacheer::putCache($cacheKey, $userProfile);
+
 // Storing data in the cache
 $Cacheer->putCache($cacheKey, $userProfile);
 
 // Retrieving data from the cache
 $cachedProfile = $Cacheer->getCache($cacheKey);
 
-if ($Cacheer->isSuccess()) {
+if ($Cacheer->has($cacheKey)) {
     echo "Cache Found: ";
     print_r($cachedProfile);
 } else {
     echo $Cacheer->getMessage();
+}
+
+// Alternatively, using the previous style
+$Cacheer->has($cacheKey);
+if ($Cacheer->isSuccess()) {
+    echo "Cache Found: ";
+    print_r($cachedProfile);
 }
 
 ```

--- a/docs/example02.md
+++ b/docs/example02.md
@@ -23,17 +23,27 @@ $dailyStats = [
     'revenue' => 500.75,
 ];
 
+// Static call example
+Cacheer::putCache($cacheKey, $dailyStats, 'namespace', '2 hours');
+
 // Armazenando dados no cache
 $Cacheer->putCache($cacheKey, $dailyStats);
 
 // Recuperando dados do cache por 2 horas
 $cachedStats = $Cacheer->getCache($cacheKey, 'namespace', '2 hours'); //Segunda opção (definição no método)
 
-if ($Cacheer->isSuccess()) {
+if ($Cacheer->has($cacheKey, 'namespace')) {
     echo "Cache Found: ";
     print_r($cachedStats);
 } else {
     echo $Cacheer->getMessage();
+}
+
+// Ou utilizando isSuccess()
+$Cacheer->has($cacheKey, 'namespace');
+if ($Cacheer->isSuccess()) {
+    echo "Cache Found: ";
+    print_r($cachedStats);
 }
 
 ```

--- a/docs/example03.md
+++ b/docs/example03.md
@@ -14,24 +14,24 @@ $options = [
 
 $Cacheer = new Cacheer($options);
 
+// Static call example
+Cacheer::flushCache();
+
 // Key of the cache to be cleared
 $cacheKey = 'user_profile_123';
 
 // Clearing a specific item from the cache
-
-$Cacheer->clearCache($cacheKey);
-
-if ($Cacheer->isSuccess()) {
-    echo $Cacheer->getMessage();
-} else {
+if ($Cacheer->clearCache($cacheKey)) {
     echo $Cacheer->getMessage();
 }
 
-$Cacheer->flushCache();
-
-if ($Cacheer->isSuccess()) {
+if ($Cacheer->flushCache()) {
     echo $Cacheer->getMessage();
-} else {
+}
+
+// Utilizando isSuccess()
+$Cacheer->clearCache($cacheKey);
+if ($Cacheer->isSuccess()) {
     echo $Cacheer->getMessage();
 }
 

--- a/docs/example04.md
+++ b/docs/example04.md
@@ -21,16 +21,26 @@ $sessionData = [
     'login_time' => time(),
 ];
 
+// Static call example
+Cacheer::putCache($cacheKey, $sessionData, $namespace);
+
 // Caching data with namespace
 $Cacheer->putCache($cacheKey, $sessionData, $namespace);
 
 // Retrieving data from the cache
 $cachedSessionData = $Cacheer->getCache($cacheKey, $namespace);
 
-if ($Cacheer->isSuccess()) {
+if ($Cacheer->has($cacheKey, $namespace)) {
     echo "Cache Found: ";
     print_r($cachedSessionData);
 } else {
     echo $Cacheer->getMessage();
+}
+
+// Alternativamente
+$Cacheer->has($cacheKey, $namespace);
+if ($Cacheer->isSuccess()) {
+    echo "Cache Found: ";
+    print_r($cachedSessionData);
 }
 ```

--- a/docs/example05.md
+++ b/docs/example05.md
@@ -18,16 +18,25 @@ $Cacheer = new Cacheer($options);
 $apiUrl = 'https://jsonplaceholder.typicode.com/posts';
 $cacheKey = 'api_response_' . md5($apiUrl);
 
+// Static call example
+$cachedResponse = Cacheer::getCache($cacheKey);
+
 // Checking if the API response is already in the cache
 $cachedResponse = $Cacheer->getCache($cacheKey);
 
-if ($Cacheer->isSuccess()) {
+if ($Cacheer->has($cacheKey)) {
     // Use the cache response
     $response = $cachedResponse;
 } else {
     // Call the API and store the response in the cache
     $response = file_get_contents($apiUrl);
     $Cacheer->putCache($cacheKey, $response);
+}
+
+// Ou utilizando isSuccess()
+$Cacheer->has($cacheKey);
+if ($Cacheer->isSuccess()) {
+    $response = $cachedResponse;
 }
 
 // Using the API response (from cache or call)

--- a/docs/example06.md
+++ b/docs/example06.md
@@ -25,6 +25,9 @@ $userProfile = [
 'email' => 'john.doe@example.com',
 ];
 
+// Static call example
+Cacheer::putCache($cacheKey, $userProfile);
+
 // Storing data in the cache
 
 $Cacheer->putCache($cacheKey, $userProfile);
@@ -32,15 +35,22 @@ $Cacheer->putCache($cacheKey, $userProfile);
 // Retrieving data from the cache in JSON format
 
 $cachedProfile = $Cacheer->getCache(
-$cacheKey, 
-$namespace, 
+$cacheKey,
+$namespace,
 $ttl)->toJson();
 
-if ($Cacheer->isSuccess()) {
+if ($Cacheer->has($cacheKey)) {
 echo  "Cache Found: ";
 print_r($cachedProfile);
 } else {
 echo  $Cacheer->getMessage();
+}
+
+// Ou utilizando isSuccess()
+$Cacheer->has($cacheKey);
+if ($Cacheer->isSuccess()) {
+echo  "Cache Found: ";
+print_r($cachedProfile);
 }
 
 ```

--- a/docs/example07.md
+++ b/docs/example07.md
@@ -26,6 +26,9 @@ $userProfile = [
 'email' => 'john.doe@example.com',
 ];
 
+// Static call example
+Cacheer::putCache($cacheKey, $userProfile);
+
 // Storing data in the cache
 
 $Cacheer->putCache($cacheKey, $userProfile);
@@ -33,15 +36,22 @@ $Cacheer->putCache($cacheKey, $userProfile);
 // Retrieving data from the cache in JSON format
 
 $cachedProfile = $Cacheer->getCache(
-$cacheKey, 
-$namespace, 
+$cacheKey,
+$namespace,
 $ttl)->toArray();
 
-if ($Cacheer->isSuccess()) {
+if ($Cacheer->has($cacheKey)) {
 echo  "Cache Found: ";
 print_r($cachedProfile);
 } else {
 echo  $Cacheer->getMessage();
+}
+
+// Ou utilizando isSuccess()
+$Cacheer->has($cacheKey);
+if ($Cacheer->isSuccess()) {
+echo  "Cache Found: ";
+print_r($cachedProfile);
 }
 
 ```

--- a/docs/example08.md
+++ b/docs/example08.md
@@ -26,6 +26,9 @@ $userProfile = [
 'email' => 'john.doe@example.com',
 ];
 
+// Static call example
+Cacheer::putCache($cacheKey, $userProfile);
+
 // Storing data in the cache
 
 $Cacheer->putCache($cacheKey, $userProfile);
@@ -33,15 +36,22 @@ $Cacheer->putCache($cacheKey, $userProfile);
 // Retrieving data from the cache in JSON format
 
 $cachedProfile = $Cacheer->getCache(
-$cacheKey, 
-$namespace, 
+$cacheKey,
+$namespace,
 $ttl)->toString();
 
-if ($Cacheer->isSuccess()) {
+if ($Cacheer->has($cacheKey)) {
 echo  "Cache Found: ";
 print_r($cachedProfile);
 } else {
 echo  $Cacheer->getMessage();
+}
+
+// Ou utilizando isSuccess()
+$Cacheer->has($cacheKey);
+if ($Cacheer->isSuccess()) {
+echo  "Cache Found: ";
+print_r($cachedProfile);
 }
 
 ```

--- a/docs/example09.md
+++ b/docs/example09.md
@@ -28,6 +28,9 @@ $userProfile = [
 'email' => 'john.doe@example.com',
 ];
 
+// Static call example
+Cacheer::putCache($cacheKey, $userProfile);
+
 // Storing data in the cache
 
 $Cacheer->putCache($cacheKey, $userProfile);
@@ -36,11 +39,18 @@ $Cacheer->putCache($cacheKey, $userProfile);
 
 $cachedProfile = $Cacheer->getCache($cacheKey);
 
-if ($Cacheer->isSuccess()) {
+if ($Cacheer->has($cacheKey)) {
 echo  "Cache Found: ";
 print_r($cachedProfile);
 } else {
 echo  $Cacheer->getMessage();
+}
+
+// Ou utilizando isSuccess()
+$Cacheer->has($cacheKey);
+if ($Cacheer->isSuccess()) {
+echo  "Cache Found: ";
+print_r($cachedProfile);
 }
 
 

--- a/docs/guide2.0.0.md
+++ b/docs/guide2.0.0.md
@@ -70,6 +70,8 @@ $Cacheer->setDriver()->useDatabaseDriver();
 
 ```
 
+> These configuration steps can also be performed statically using `Cacheer::setConfig()->setDatabaseConnection('mysql');`
+
 #### 3) Configure Timezone
 
 - To avoid issues with cache expiration, set the timezone:

--- a/src/CacheStore/ArrayCacheStore.php
+++ b/src/CacheStore/ArrayCacheStore.php
@@ -248,7 +248,15 @@ class ArrayCacheStore implements CacheerInterface
   public function has(string $cacheKey, string $namespace = ''): bool
   {
     $arrayStoreKey = $this->buildArrayKey($cacheKey, $namespace);
-    return isset($this->arrayStore[$arrayStoreKey]) && time() < $this->arrayStore[$arrayStoreKey]['expirationTime'];
+    $exists = isset($this->arrayStore[$arrayStoreKey]) && time() < $this->arrayStore[$arrayStoreKey]['expirationTime'];
+
+    $this->setMessage(
+      $exists ? "Cache key: {$cacheKey} exists and it's available!" : "Cache key: {$cacheKey} does not exist or it's expired!",
+      $exists
+    );
+    $this->logger->debug("{$this->getMessage()} from array driver.");
+
+    return $exists;
   }
 
   /**

--- a/src/CacheStore/DatabaseCacheStore.php
+++ b/src/CacheStore/DatabaseCacheStore.php
@@ -185,15 +185,22 @@ class DatabaseCacheStore implements CacheerInterface
      * 
      * @param string $cacheKey
      * @param string $namespace
-     * @return void
+     * @return bool
      */
-    public function has(string $cacheKey, string $namespace = ''): void
+    public function has(string $cacheKey, string $namespace = ''): bool
     {
         $cacheData = $this->getCache($cacheKey, $namespace);
+
         if ($cacheData) {
-            $this->logger->debug("Cache key: {$cacheKey} exists and it's available from database driver.");
+            $this->setMessage("Cache key: {$cacheKey} exists and it's available from database driver.", true);
+            $this->logger->debug("{$this->getMessage()}");
+            return true;
         }
-        $this->logger->warning("{$this->getMessage()} from database driver.");
+
+        $this->setMessage("Cache key: {$cacheKey} does not exist or it's expired from database driver.", false);
+        $this->logger->debug("{$this->getMessage()}");
+
+        return false;
     }
 
     /**

--- a/src/CacheStore/FileCacheStore.php
+++ b/src/CacheStore/FileCacheStore.php
@@ -131,7 +131,7 @@ class FileCacheStore implements CacheerInterface
      *
      * @param string $cacheKey
      * @param string $namespace
-     * @return void
+     * @return bool
      * @throws CacheFileException
      */
     public function clearCache(string $cacheKey, string $namespace = ''): void
@@ -340,18 +340,20 @@ class FileCacheStore implements CacheerInterface
      *
      * @param string $cacheKey
      * @param string $namespace
-     * @return void
+     * @return bool
      * @throws CacheFileException
      */
-    public function has(string $cacheKey, string $namespace = ''): void
+    public function has(string $cacheKey, string $namespace = ''): bool
     {
         $this->getCache($cacheKey, $namespace);
 
         if ($this->isSuccess()) {
             $this->setMessage("Cache key: {$cacheKey} exists and it's available! from file driver", true);
-        } else {
-            $this->setMessage("Cache key: {$cacheKey} does not exists or it's expired! from file driver", false);
+            return true;
         }
+
+        $this->setMessage("Cache key: {$cacheKey} does not exists or it's expired! from file driver", false);
+        return false;
     }
 
     /**

--- a/src/CacheStore/RedisCacheStore.php
+++ b/src/CacheStore/RedisCacheStore.php
@@ -56,7 +56,7 @@ class RedisCacheStore implements CacheerInterface
      * @param string $cacheKey
      * @param mixed  $cacheData
      * @param string $namespace
-     * @return void
+     * @return bool
      */
     public function appendCache(string $cacheKey, mixed $cacheData, string $namespace = ''): void
     {
@@ -233,19 +233,21 @@ class RedisCacheStore implements CacheerInterface
      * 
      * @param string $cacheKey
      * @param string $namespace
-     * @return void
+     * @return bool
      */
-    public function has(string $cacheKey, string $namespace = ''): void
+    public function has(string $cacheKey, string $namespace = ''): bool
     {
         $cacheFullKey = $this->buildKey($cacheKey, $namespace);
 
         if ($this->redis->exists($cacheFullKey) > 0) {
             $this->setMessage("Cache Key: {$cacheKey} exists!", true);
-        } else {
-            $this->setMessage("Cache Key: {$cacheKey} does not exists!", false);
+            $this->logger->debug("{$this->getMessage()} from redis driver.");
+            return true;
         }
 
+        $this->setMessage("Cache Key: {$cacheKey} does not exists!", false);
         $this->logger->debug("{$this->getMessage()} from redis driver.");
+        return false;
     }
 
     /**

--- a/src/Cacheer.php
+++ b/src/Cacheer.php
@@ -3,7 +3,6 @@
 namespace Silviooosilva\CacheerPhp;
 
 use Closure;
-use Silviooosilva\CacheerPhp\Interface\CacheerInterface;
 use Silviooosilva\CacheerPhp\CacheStore\DatabaseCacheStore;
 use Silviooosilva\CacheerPhp\CacheStore\FileCacheStore;
 use Silviooosilva\CacheerPhp\CacheStore\RedisCacheStore;
@@ -14,13 +13,14 @@ use Silviooosilva\CacheerPhp\Utils\CacheDriver;
 use RuntimeException;
 use Silviooosilva\CacheerPhp\Service\CacheRetriever;
 use Silviooosilva\CacheerPhp\Service\CacheMutator;
+use BadMethodCallException;
 
 /**
 * Class CacheerPHP
 * @author Sílvio Silva <https://github.com/silviooosilva>
 * @package Silviooosilva\CacheerPhp
 */
-final class Cacheer implements CacheerInterface
+final class Cacheer
 {
     /**
     * @var string
@@ -67,6 +67,11 @@ final class Cacheer implements CacheerInterface
     */
     private CacheMutator $mutator;
 
+    /**
+    * @var Cacheer|null
+    */
+    private static ?Cacheer $staticInstance = null;
+
 /**
     * Cacheer constructor.
     *
@@ -83,152 +88,9 @@ final class Cacheer implements CacheerInterface
         $this->setDriver()->useDefaultDriver();
     }
 
-    /**
-    * Adds data to the cache if it does not already exist.
-    *
-    * @param string $cacheKey
-    * @param mixed  $cacheData
-    * @param string $namespace
-    * @param int|string $ttl
-    * @return bool
-    */
-    public function add(string $cacheKey, mixed $cacheData, string $namespace = '', int|string $ttl = 3600): bool
+    private static function instance(): Cacheer
     {
-        return $this->mutator->add($cacheKey, $cacheData, $namespace, $ttl);
-    }
-
-    /**
-    * Appends data to an existing cache item.
-    * 
-    * @param string $cacheKey
-    * @param mixed  $cacheData
-    * @param string $namespace
-    * @return void
-    */
-    public function appendCache(string $cacheKey, mixed $cacheData, string $namespace = ''): void
-    {
-        $this->mutator->appendCache($cacheKey, $cacheData, $namespace);
-    }
-
-    /**
-    * Clears a specific cache item.
-    * 
-    * @param string $cacheKey
-    * @param string $namespace
-    * @return void
-    */
-    public function clearCache(string $cacheKey, string $namespace = ''): void
-    {
-        $this->mutator->clearCache($cacheKey, $namespace);
-    }
-
-    /**
-    * Decrements a cache item by a specified amount.
-    *  
-    * @param string $cacheKey
-    * @param int $amount
-    * @param string $namespace
-    * @return bool
-    */
-    public function decrement(string $cacheKey, int $amount = 1, string $namespace = ''): bool
-    {
-        return $this->mutator->decrement($cacheKey, $amount, $namespace);
-    }
-
-    /**
-    * Store data in the cache permanently.
-    *
-    * @param string $cacheKey
-    * @param mixed $cacheData
-    * @return void
-    */
-    public function forever(string $cacheKey, mixed $cacheData): void
-    {
-        $this->mutator->forever($cacheKey, $cacheData);
-    }
-
-    /**
-    * Flushes all cache items.
-    * 
-    * @return void
-    */
-    public function flushCache(): void
-    {
-        $this->mutator->flushCache();
-    }
-
-    /**
-    * Retrieves a cache item and deletes it from the cache.
-    * 
-    * @param string $cacheKey
-    * @param string $namespace
-    * @return mixed
-    */
-    public function getAndForget(string $cacheKey, string $namespace = ''): mixed
-    {
-        return $this->retriever->getAndForget($cacheKey, $namespace);
-    }
-
-    /**
-    * Gets all items in a specific namespace.
-    * 
-    * @param string $namespace
-    * @return CacheDataFormatter|mixed
-    */
-    public function getAll(string $namespace = ''): mixed
-    {
-        return $this->retriever->getAll($namespace);
-    }
-
-    /**
-    * Retrieves a single cache item.
-    * 
-    * @param string $cacheKey
-    * @param string $namespace
-    * @param string|int $ttl
-    * @return CacheDataFormatter|mixed
-    */
-    public function getCache(string $cacheKey, string $namespace = '', string|int $ttl = 3600): mixed
-    {
-        return $this->retriever->getCache($cacheKey, $namespace, $ttl);
-    }
-
-    /**
-    * Retrieves multiple cache items by their keys.
-    * 
-    * @param array $cacheKeys
-    * @param string $namespace
-    * @param string|int $ttl
-    * @return CacheDataFormatter|array
-     */
-    public function getMany(array $cacheKeys, string $namespace = '', string|int $ttl = 3600): CacheDataFormatter|array
-    {
-        return $this->retriever->getMany($cacheKeys, $namespace, $ttl);
-    }
-
-    /**
-    * Checks if a cache item exists.
-    * 
-    * @param string $cacheKey
-    * @param string $namespace
-    * @return void
-    */
-    public function has(string $cacheKey, string $namespace = ''): void
-    {
-        $this->retriever->has($cacheKey, $namespace);
-    }
-
-    /**
-    * Increments a cache item by a specified amount.
-    * 
-    * @param string $cacheKey
-    * @param int $amount
-    * @param string $namespace
-    * @return bool
-    */
-    public function increment(string $cacheKey, int $amount = 1, string $namespace = ''): bool
-    {
-        return $this->mutator->increment($cacheKey, $amount, $namespace);
+        return self::$staticInstance ??= new self();
     }
 
     /**
@@ -239,71 +101,6 @@ final class Cacheer implements CacheerInterface
     public function isSuccess(): bool
     {
         return $this->success;
-    }
-
-    /**
-    * Stores an item in the cache with a specific TTL.
-    * 
-    * @param string $cacheKey
-    * @param mixed  $cacheData
-    * @param string $namespace
-    * @param string|int $ttl
-    * @return void
-    */
-    public function putCache(string $cacheKey, mixed $cacheData, string $namespace = '', string|int $ttl = 3600): void
-    {
-        $this->mutator->putCache($cacheKey, $cacheData, $namespace, $ttl);
-    }
-
-    /**
-    * Stores multiple items in the cache.
-    *  
-    * @param array   $items
-    * @param string  $namespace
-    * @param integer $batchSize
-    * @return void
-    */
-    public function putMany(array $items, string $namespace = '', int $batchSize = 100): void
-    {
-        $this->mutator->putMany($items, $namespace, $batchSize);
-    }
-
-    /**
-    * Renews the cache for a specific key with a new TTL.
-    * 
-    * @param string $cacheKey
-    * @param string|int $ttl
-    * @param string $namespace
-    * @return void
-    */
-    public function renewCache(string $cacheKey, string|int $ttl = 3600, string $namespace = ''): void
-    {
-        $this->mutator->renewCache($cacheKey, $ttl, $namespace);
-    }
-
-    /**
-    * Retrieves a cache item or executes a callback to store it if not found.
-    * 
-    * @param string $cacheKey
-    * @param int|string $ttl
-    * @param Closure $callback
-    * @return mixed
-    */
-    public function remember(string $cacheKey, int|string $ttl, Closure $callback): mixed
-    {
-        return $this->retriever->remember($cacheKey, $ttl, $callback);
-    }
-
-    /**
-    * Retrieves a cache item or executes a callback to store it permanently if not found.
-    * 
-    * @param string $cacheKey
-    * @param Closure $callback
-    * @return mixed
-    */
-    public function rememberForever(string $cacheKey, Closure $callback): mixed
-    {
-        return $this->retriever->rememberForever($cacheKey, $callback);
     }
 
     /**
@@ -434,5 +231,39 @@ final class Cacheer implements CacheerInterface
     {
         $this->encryptionKey = $key;
         return $this;
+    }
+
+    /**
+    * Dynamically handle calls to missing instance methods.
+    *
+    * @param string $method
+    * @param array $parameters
+    * @return mixed
+    */
+    public function __call(string $method, array $parameters): mixed
+    {
+        if (method_exists($this->mutator, $method)) {
+            return $this->mutator->{$method}(...$parameters);
+        }
+
+        if (method_exists($this->retriever, $method)) {
+            return $this->retriever->{$method}(...$parameters);
+        }
+
+        throw new BadMethodCallException("Method {$method} does not exist");
+    }
+
+    /**
+    * Handle dynamic static calls by routing them through an instance.
+    *
+    * @param string $method
+    * @param array $parameters
+    * @return mixed
+    */
+    public static function __callStatic(string $method, array $parameters): mixed
+    {
+        $instance = self::instance();
+
+        return $instance->__call($method, $parameters);
     }
 }

--- a/src/Interface/CacheerInterface.php
+++ b/src/Interface/CacheerInterface.php
@@ -71,7 +71,7 @@ interface CacheerInterface
      * @param string $namespace Namespace for organization
      * @return bool True if the item exists, false otherwise
      */
-    public function has(string $cacheKey, string $namespace = '');
+    public function has(string $cacheKey, string $namespace = ''): bool;
 
     /**
      * Stores an item in the cache with a specific TTL.

--- a/src/Service/CacheMutator.php
+++ b/src/Service/CacheMutator.php
@@ -54,12 +54,14 @@ class CacheMutator
     * @param string $cacheKey
     * @param mixed $cacheData
     * @param string $namespace
-    * @return void
+    * @return bool
     */
-    public function appendCache(string $cacheKey, mixed $cacheData, string $namespace = ''): void
+    public function appendCache(string $cacheKey, mixed $cacheData, string $namespace = ''): bool
     {
         $this->cacheer->cacheStore->appendCache($cacheKey, $cacheData, $namespace);
         $this->cacheer->syncState();
+
+        return $this->cacheer->isSuccess();
     }
 
     /**
@@ -67,12 +69,14 @@ class CacheMutator
     *
     * @param string $cacheKey
     * @param string $namespace
-    * @return void
+    * @return bool
     */
-    public function clearCache(string $cacheKey, string $namespace = ''): void
+    public function clearCache(string $cacheKey, string $namespace = ''): bool
     {
         $this->cacheer->cacheStore->clearCache($cacheKey, $namespace);
         $this->cacheer->syncState();
+
+        return $this->cacheer->isSuccess();
     }
 
     /**
@@ -93,23 +97,27 @@ class CacheMutator
      *
      * @param string $cacheKey
      * @param mixed $cacheData
-     * @return void
+     * @return bool
      */
-    public function forever(string $cacheKey, mixed $cacheData): void
+    public function forever(string $cacheKey, mixed $cacheData): bool
     {
         $this->putCache($cacheKey, $cacheData, ttl: 31536000 * 1000);
         $this->cacheer->setInternalState($this->cacheer->getMessage(), $this->cacheer->isSuccess());
+
+        return $this->cacheer->isSuccess();
     }
 
     /**
     * Flushes the entire cache.
     *
-    * @return void
+    * @return bool
     */
-    public function flushCache(): void
+    public function flushCache(): bool
     {
         $this->cacheer->cacheStore->flushCache();
         $this->cacheer->syncState();
+
+        return $this->cacheer->isSuccess();
     }
 
     /**
@@ -140,13 +148,15 @@ class CacheMutator
      * @param mixed $cacheData
      * @param string $namespace
      * @param int|string $ttl
-     * @return void
+     * @return bool
      */
-    public function putCache(string $cacheKey, mixed $cacheData, string $namespace = '', int|string $ttl = 3600): void
+    public function putCache(string $cacheKey, mixed $cacheData, string $namespace = '', int|string $ttl = 3600): bool
     {
         $data = CacheerHelper::prepareForStorage($cacheData, $this->cacheer->isCompressionEnabled(), $this->cacheer->getEncryptionKey());
         $this->cacheer->cacheStore->putCache($cacheKey, $data, $namespace, $ttl);
         $this->cacheer->syncState();
+
+        return $this->cacheer->isSuccess();
     }
 
     /**
@@ -155,11 +165,14 @@ class CacheMutator
     * @param array $items
     * @param string $namespace
     * @param int $batchSize
-    * @return void
+    * @return bool
     */
-    public function putMany(array $items, string $namespace = '', int $batchSize = 100): void
+    public function putMany(array $items, string $namespace = '', int $batchSize = 100): bool
     {
         $this->cacheer->cacheStore->putMany($items, $namespace, $batchSize);
+        $this->cacheer->syncState();
+
+        return $this->cacheer->isSuccess();
     }
 
     /**
@@ -168,11 +181,13 @@ class CacheMutator
     * @param string $cacheKey
     * @param int|string $ttl
     * @param string $namespace
-    * @return void
+    * @return bool
     */
-    public function renewCache(string $cacheKey, int|string $ttl = 3600, string $namespace = ''): void
+    public function renewCache(string $cacheKey, int|string $ttl = 3600, string $namespace = ''): bool
     {
         $this->cacheer->cacheStore->renewCache($cacheKey, $ttl, $namespace);
         $this->cacheer->syncState();
+
+        return $this->cacheer->isSuccess();
     }
 }

--- a/src/Service/CacheRetriever.php
+++ b/src/Service/CacheRetriever.php
@@ -140,13 +140,15 @@ class CacheRetriever
      *
      * @param string $cacheKey
      * @param string $namespace
-     * @return void
+     * @return bool
      * @throws CacheFileException
      */
-    public function has(string $cacheKey, string $namespace = ''): void
+    public function has(string $cacheKey, string $namespace = ''): bool
     {
-        $this->cacheer->cacheStore->has($cacheKey, $namespace);
+        $result = $this->cacheer->cacheStore->has($cacheKey, $namespace);
         $this->cacheer->syncState();
+
+        return $result;
     }
 
     /**

--- a/tests/Unit/BooleanReturnTest.php
+++ b/tests/Unit/BooleanReturnTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Silviooosilva\CacheerPhp\Cacheer;
+
+class BooleanReturnTest extends TestCase
+{
+    private Cacheer $cache;
+
+    protected function setUp(): void
+    {
+        $this->cache = new Cacheer();
+        $this->cache->setDriver()->useArrayDriver();
+    }
+
+    public function testHasReturnsBoolean()
+    {
+        $this->cache->putCache('bool_key', 'value');
+        $this->assertTrue($this->cache->has('bool_key'));
+        $this->assertTrue($this->cache->isSuccess());
+
+        $this->assertFalse($this->cache->has('unknown_key'));
+        $this->assertFalse($this->cache->isSuccess());
+    }
+
+    public function testMutatingMethodsReturnBoolean()
+    {
+        $this->assertTrue($this->cache->putCache('k', 'v'));
+        $this->assertTrue($this->cache->flushCache());
+        $this->assertTrue($this->cache->putCache('k', 'v'));
+        $this->assertTrue($this->cache->clearCache('k'));
+    }
+}

--- a/tests/Unit/StaticAccessTest.php
+++ b/tests/Unit/StaticAccessTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Silviooosilva\CacheerPhp\Cacheer;
+
+final class StaticAccessTest extends TestCase
+{
+    public function testFlushCacheStatic(): void
+    {
+        $result = Cacheer::flushCache();
+        $this->assertIsBool($result);
+    }
+
+    public function testFlushCacheDynamic(): void
+    {
+        $cache = new Cacheer();
+        $this->assertIsBool($cache->flushCache());
+    }
+}


### PR DESCRIPTION
## Summary
- Delegate all cache operations through magic dispatch for seamless static and dynamic usage
- Bump package version to v4.4.1

## Testing
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aa693167708332ae542cb21d2119a3